### PR TITLE
Update products table

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,14 +2,14 @@
 #
 # Table name: products
 #
-#  id             :integer          not null, primary key
+#  id             :bigint           not null, primary key
 #  name           :string           not null
 #  description    :text
-#  quantity       :integer
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  available      :boolean          default(TRUE)
 #  price_cents    :integer          default(0), not null
 #  price_currency :string           default("BRL"), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
 #
 class Product < ApplicationRecord
   monetize :price_cents

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -3,6 +3,6 @@
     <%= link_to "Edite esse produto", edit_product_path(product) %>
     <%= product.name %>
     <%= product.description%>
-    <%= product.quantity%>
+    <%= product.available?%>
   </li>
 </div>

--- a/db/migrate/20240213003128_change_column_in_products.rb
+++ b/db/migrate/20240213003128_change_column_in_products.rb
@@ -1,0 +1,6 @@
+class ChangeColumnInProducts < ActiveRecord::Migration[7.0]
+  def change
+    change_column :products, :quantity, :boolean, default: true, using: 'quantity::boolean'
+    rename_column :products, :quantity, :available
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_20_213639) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_13_003128) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "products", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
-    t.integer "quantity"
+    t.boolean "available", default: true
     t.integer "price_cents", default: 0, null: false
     t.string "price_currency", default: "BRL", null: false
     t.datetime "created_at", null: false

--- a/spec/factories/product.rb
+++ b/spec/factories/product.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :product do
     name { Faker::Food.dish }
     description { Faker::Food.description }
-    quantity { rand(1..5) }
     price_cents { rand(1..3000) }
   end
 end


### PR DESCRIPTION
Decided that `quantity` column for products wasn't going to be necessary, if needed in the future then will reconsider

- rails generate migration ChangeColumnInProducts
  - had to add `using: 'quantity::boolean'` after error showed up when I `rails db:migrate`
<img width="1077" alt="Screenshot 2024-02-12 at 16 49 23" src="https://github.com/KomCath/queijos_app/assets/46489914/25eeba6b-a7e1-47ae-8db8-0d9edff1fa7b">

- bundle exec annotate --models
  - cuz just `annotate --models` isn't the way to go lol

- removed `quantity` from where was being used
